### PR TITLE
[#6] feat: user notification url

### DIFF
--- a/src/main/java/com/popjub/userservice/UserServiceApplication.java
+++ b/src/main/java/com/popjub/userservice/UserServiceApplication.java
@@ -3,11 +3,15 @@ package com.popjub.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.popjub.common.exception.GlobalExceptionHandler;
 
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableDiscoveryClient
+@Import(GlobalExceptionHandler.class)
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/popjub/userservice/application/dto/command/UpdateNotificationUrlsCommand.java
+++ b/src/main/java/com/popjub/userservice/application/dto/command/UpdateNotificationUrlsCommand.java
@@ -1,0 +1,11 @@
+package com.popjub.userservice.application.dto.command;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateNotificationUrlsCommand(
+	Long userId,
+	String slackUrl,
+	String discordUrl
+) {
+}

--- a/src/main/java/com/popjub/userservice/application/service/UserService.java
+++ b/src/main/java/com/popjub/userservice/application/service/UserService.java
@@ -1,0 +1,36 @@
+package com.popjub.userservice.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.popjub.userservice.application.dto.command.UpdateNotificationUrlsCommand;
+import com.popjub.userservice.domain.entity.User;
+import com.popjub.userservice.domain.repository.UserRepository;
+import com.popjub.userservice.exception.UserCustomException;
+import com.popjub.userservice.exception.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void updateNotificationUrls(UpdateNotificationUrlsCommand command) {
+		User user = userRepository.findById(command.userId())
+			.orElseThrow(() -> new UserCustomException(UserErrorCode.NOT_FOUND_USER));
+
+		user.updateNotificationUrls(command.slackUrl(), command.discordUrl());
+
+		log.info("알림 URL 업데이트 성공 - userId: {}, slackUrl: {}, discordUrl: {}",
+			command.userId(),
+			command.slackUrl() != null ? "설정됨" : "미설정",
+			command.discordUrl() != null ? "설정됨" : "미설정"
+		);
+	}
+}

--- a/src/main/java/com/popjub/userservice/domain/entity/User.java
+++ b/src/main/java/com/popjub/userservice/domain/entity/User.java
@@ -44,6 +44,12 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private UserRole role;
 
+	@Column(name = "slack_url")
+	private String slackUrl;
+
+	@Column(name = "discord_url")
+	private String discordUrl;
+
 	@Builder(access = AccessLevel.PRIVATE)
 	private User(String email, String password, String nickName, String userName, String phone, UserRole role) {
 		this.email = email;
@@ -96,5 +102,10 @@ public class User extends BaseEntity {
 			.phone(phone)
 			.role(role)
 			.build();
+	}
+
+	public void updateNotificationUrls(String slackUrl, String discordUrl) {
+		this.slackUrl = slackUrl;
+		this.discordUrl = discordUrl;
 	}
 }

--- a/src/main/java/com/popjub/userservice/domain/repository/UserRepository.java
+++ b/src/main/java/com/popjub/userservice/domain/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository {
 	boolean existsByNickName(String nickName);
 
 	Optional<User> findByEmail(String email);
+
+	Optional<User> findById(Long userId);
 }

--- a/src/main/java/com/popjub/userservice/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/popjub/userservice/infrastructure/repository/UserRepositoryImpl.java
@@ -34,4 +34,9 @@ public class UserRepositoryImpl implements UserRepository {
 	public Optional<User> findByEmail(String email) {
 		return userJpaRepository.findByEmail(email);
 	}
+
+	@Override
+	public Optional<User> findById(Long userId) {
+		return userJpaRepository.findById(userId);
+	}
 }

--- a/src/main/java/com/popjub/userservice/presentation/controller/UserController.java
+++ b/src/main/java/com/popjub/userservice/presentation/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.popjub.userservice.presentation.controller;
+
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.popjub.common.enums.SuccessCode;
+import com.popjub.common.response.ApiResponse;
+import com.popjub.userservice.application.service.UserService;
+import com.popjub.userservice.presentation.dto.request.UpdateNotificationUrlsRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+	private final UserService userService;
+
+	@PutMapping("/me/notification-urls")
+	public ApiResponse<Void> updateUserNotificationUrls(
+		@RequestBody UpdateNotificationUrlsRequest request
+	) {
+		/**
+		 * TODO: @CurrentUser 로 바꿀 예정 - 임시 userId = 1
+		 */
+		Long userId = 1L;
+
+		userService.updateNotificationUrls(request.toCommand(userId));
+
+		return ApiResponse.<Void>builder()
+			.message("알림받을 디스코드/슬랙 url 등록에 성공했습니다.")
+			.code(SuccessCode.OK)
+			.build();
+	}
+}

--- a/src/main/java/com/popjub/userservice/presentation/dto/request/UpdateNotificationUrlsRequest.java
+++ b/src/main/java/com/popjub/userservice/presentation/dto/request/UpdateNotificationUrlsRequest.java
@@ -1,0 +1,16 @@
+package com.popjub.userservice.presentation.dto.request;
+
+import com.popjub.userservice.application.dto.command.UpdateNotificationUrlsCommand;
+
+public record UpdateNotificationUrlsRequest(
+	String slackUrl,
+	String discordUrl
+) {
+	public UpdateNotificationUrlsCommand toCommand(Long userId) {
+		return UpdateNotificationUrlsCommand.builder()
+			.userId(userId)
+			.slackUrl(slackUrl)
+			.discordUrl(discordUrl)
+			.build();
+	}
+}


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
- #6 

## 📝 작업 내용 상세 작성
- User 엔티티에 discordUrl, slackUrl 필드 추가
- discordUrl, slackUrl 등록api 
- 임시로 userId 1로 테스트 진행

## 🚀 PR 타입
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더 수정, 삭제

## 👀 참고 사항
- api 명세서에도 추가 해놨습니다.